### PR TITLE
ci: use npm trusted publishers with OIDC provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -22,8 +23,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.15.0
-          cache: pnpm
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 
@@ -33,5 +34,4 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with OIDC-based trusted publisher authentication
- Add `id-token: write` permission for GitHub OIDC token exchange
- Add `NPM_CONFIG_PROVENANCE: true` for signed provenance attestations on every publish
- Set `package-manager-cache: false` per npm trusted publisher docs

No long-lived npm access tokens needed — auth happens via short-lived OIDC tokens tied to the workflow.

Depends on #3.

## Test plan

- [ ] Verify trusted publisher is configured on npmjs.com for this package
- [ ] Merge #3 first, then merge this to trigger a release