### PR TITLE
feat!: decouple React bindings from core event emitters

### DIFF
--- a/.changeset/decouple-react-bindings.md
+++ b/.changeset/decouple-react-bindings.md
@@ -1,0 +1,5 @@
+---
+"use-custom-event": major
+---
+
+Decouple React hooks from core event emitters. The root entry point (`use-custom-event`) and broadcast entry point (`use-custom-event/broadcast`) no longer depend on React. Import from `use-custom-event/react` or `use-custom-event/broadcast/react` for React hook support.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
           registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+      - uses: changesets/action@d94a5c301145045a0960133674e003b265942a22 # v1.8.0
         with:
           publish: pnpm run release
           version: pnpm run version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,12 @@ A typed custom event emitter for React using the Standard Schema interface for r
 
 ## Architecture
 
-- `src/index.ts` — custom event emitter using DOM CustomEvent API
-- `src/broadcast.ts` — cross-tab event emitter using BroadcastChannel API
-- Both accept any Standard Schema compliant validator (zod 3.24+, valibot, arktype, etc.)
+- `src/index.ts` — core custom event emitter using DOM CustomEvent API (no React dependency)
+- `src/react.ts` — React bindings wrapping core event emitter with `useEventListener` hook
+- `src/broadcast.ts` — core cross-tab event emitter using BroadcastChannel API (no React dependency)
+- `src/broadcast-react.ts` — React bindings wrapping broadcast event emitter with `useEventListener` hook
+- All modules accept any Standard Schema compliant validator (zod 3.24+, valibot, arktype, etc.)
+- React is an optional peer dependency — only needed when importing from `/react` or `/broadcast/react` paths
 
 ## Supply Chain Config — Do Not Modify Without Approval
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Bundle Size](https://img.shields.io/bundlephobia/minzip/use-custom-event) ![npm version](https://badgen.net/npm/v/use-custom-event) ![types](https://badgen.net/npm/types/use-custom-event)
 
-Typed custom event emitters for React with runtime validation via [Standard Schema](https://github.com/standard-schema/standard-schema). Works with any compatible validation library — no adapter needed.
+Typed custom event emitters with runtime validation via [Standard Schema](https://github.com/standard-schema/standard-schema). Framework-agnostic core with optional React bindings. Works with any compatible validation library — no adapter needed.
 
 ## Compatible Validation Libraries
 
@@ -25,21 +25,41 @@ Any library that implements the [Standard Schema](https://github.com/standard-sc
 pnpm add use-custom-event
 ```
 
+## Entry Points
+
+| Import Path                        | Description                          | Requires React |
+| ---------------------------------- | ------------------------------------ | -------------- |
+| `use-custom-event`                 | Core event emitter (DOM CustomEvent) | No             |
+| `use-custom-event/react`           | Core + `useEventListener` hook       | Yes            |
+| `use-custom-event/broadcast`       | BroadcastChannel event emitter       | No             |
+| `use-custom-event/broadcast/react` | Broadcast + `useEventListener` hook  | Yes            |
+
 ## Usage with Zod
 
-```tsx
+### Core (no React dependency)
+
+```ts
 import { z } from "zod";
 import { createEventEmitter } from "use-custom-event";
 
-const { emit, subscribe, useEventListener } = createEventEmitter(
-  "my-event",
-  z.object({ name: z.string() }),
-);
+const { emit, subscribe } = createEventEmitter("my-event", z.object({ name: z.string() }));
 
 const unsubscribe = subscribe((data) => {
   console.log(data.name); // strictly typed
 });
 unsubscribe();
+```
+
+### With React
+
+```tsx
+import { z } from "zod";
+import { createEventEmitter } from "use-custom-event/react";
+
+const { emit, subscribe, useEventListener } = createEventEmitter(
+  "my-event",
+  z.object({ name: z.string() }),
+);
 
 function App() {
   useEventListener(
@@ -54,122 +74,55 @@ function App() {
 
 ## Usage with Valibot
 
-```tsx
+```ts
 import * as v from "valibot";
 import { createEventEmitter } from "use-custom-event";
 
-const { emit, subscribe, useEventListener } = createEventEmitter(
-  "my-event",
-  v.object({ name: v.string() }),
-);
-
-const unsubscribe = subscribe((data) => {
-  console.log(data.name);
-});
-unsubscribe();
-
-function App() {
-  useEventListener(
-    useCallback((data) => {
-      console.log(data.name);
-    }, []),
-  );
-
-  return <button onClick={() => emit({ name: "hello" })}>Trigger</button>;
-}
+const { emit, subscribe } = createEventEmitter("my-event", v.object({ name: v.string() }));
 ```
 
 ## Usage with ArkType
 
-```tsx
+```ts
 import { type } from "arktype";
 import { createEventEmitter } from "use-custom-event";
 
-const { emit, subscribe, useEventListener } = createEventEmitter(
-  "my-event",
-  type({ name: "string" }),
-);
-
-const unsubscribe = subscribe((data) => {
-  console.log(data.name);
-});
-unsubscribe();
-
-function App() {
-  useEventListener(
-    useCallback((data) => {
-      console.log(data.name);
-    }, []),
-  );
-
-  return <button onClick={() => emit({ name: "hello" })}>Trigger</button>;
-}
+const { emit, subscribe } = createEventEmitter("my-event", type({ name: "string" }));
 ```
 
 ## Usage with Effect Schema
 
-```tsx
+```ts
 import { Schema } from "effect";
 import { createEventEmitter } from "use-custom-event";
 
-const { emit, subscribe, useEventListener } = createEventEmitter(
-  "my-event",
-  Schema.Struct({ name: Schema.String }),
-);
-
-const unsubscribe = subscribe((data) => {
-  console.log(data.name);
-});
-unsubscribe();
-
-function App() {
-  useEventListener(
-    useCallback((data) => {
-      console.log(data.name);
-    }, []),
-  );
-
-  return <button onClick={() => emit({ name: "hello" })}>Trigger</button>;
-}
+const { emit, subscribe } = createEventEmitter("my-event", Schema.Struct({ name: Schema.String }));
 ```
 
 ## Usage with Yup
 
-```tsx
+```ts
 import * as yup from "yup";
 import { createEventEmitter } from "use-custom-event";
 
-const { emit, subscribe, useEventListener } = createEventEmitter(
+const { emit, subscribe } = createEventEmitter(
   "my-event",
   yup.object({ name: yup.string().required() }),
 );
-
-const unsubscribe = subscribe((data) => {
-  console.log(data.name);
-});
-unsubscribe();
-
-function App() {
-  useEventListener(
-    useCallback((data) => {
-      console.log(data.name);
-    }, []),
-  );
-
-  return <button onClick={() => emit({ name: "hello" })}>Trigger</button>;
-}
 ```
 
 ## Broadcast Channel
 
 [Broadcast Channel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) enables communication between tabs/windows of the same origin. Works with any compatible validation library.
 
-```tsx
+### Core (no React dependency)
+
+```ts
 import { z } from "zod";
 import { createBroadcastChannelEventEmitter } from "use-custom-event/broadcast";
 
 const channel = new BroadcastChannel("my-channel");
-const { emit, subscribe, useEventListener } = createBroadcastChannelEventEmitter(
+const { emit, subscribe } = createBroadcastChannelEventEmitter(
   channel,
   z.object({ name: z.string() }),
 );
@@ -178,6 +131,19 @@ const unsubscribe = subscribe((data) => {
   console.log(data.name);
 });
 unsubscribe();
+```
+
+### With React
+
+```tsx
+import { z } from "zod";
+import { createBroadcastChannelEventEmitter } from "use-custom-event/broadcast/react";
+
+const channel = new BroadcastChannel("my-channel");
+const { emit, useEventListener } = createBroadcastChannelEventEmitter(
+  channel,
+  z.object({ name: z.string() }),
+);
 
 function App() {
   useEventListener(
@@ -189,6 +155,22 @@ function App() {
   return <button onClick={() => emit({ name: "hello" })}>Trigger</button>;
 }
 ```
+
+## Migrating from v3
+
+v4 decouples React bindings from the core modules. The root entry point (`use-custom-event`) and broadcast entry point (`use-custom-event/broadcast`) no longer depend on React or export `useEventListener`. Import from the `/react` subpath instead:
+
+```diff
+- import { createEventEmitter } from "use-custom-event";
++ import { createEventEmitter } from "use-custom-event/react";
+```
+
+```diff
+- import { createBroadcastChannelEventEmitter } from "use-custom-event/broadcast";
++ import { createBroadcastChannelEventEmitter } from "use-custom-event/broadcast/react";
+```
+
+If you only use `emit` and `subscribe` (no hooks), your imports stay the same — no changes needed.
 
 ## Migrating from v2
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-custom-event",
   "version": "2.0.1",
-  "description": "Typed custom event emitters for React with Standard Schema validation",
+  "description": "Typed custom event emitters with Standard Schema validation — framework-agnostic core with optional React bindings",
   "keywords": [
     "arktype",
     "broadcast-channel",
@@ -38,10 +38,20 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    },
     "./broadcast": {
       "types": "./dist/broadcast.d.ts",
       "import": "./dist/broadcast.js",
       "require": "./dist/broadcast.cjs"
+    },
+    "./broadcast/react": {
+      "types": "./dist/broadcast/react.d.ts",
+      "import": "./dist/broadcast/react.js",
+      "require": "./dist/broadcast/react.cjs"
     },
     "./package.json": {
       "default": "./package.json"
@@ -85,6 +95,11 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=24.15.0"

--- a/src/broadcast-react.ts
+++ b/src/broadcast-react.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { createBroadcastChannelEventEmitter as createCoreBroadcastEmitter } from "./broadcast";
+
+export type { StandardSchemaV1 } from "@standard-schema/spec";
+
+export function createBroadcastChannelEventEmitter<T extends StandardSchemaV1>(
+  channel: BroadcastChannel,
+  schema: T,
+) {
+  const core = createCoreBroadcastEmitter(channel, schema);
+
+  type EventOutput = StandardSchemaV1.InferOutput<T>;
+  type EventCallback = (data: EventOutput) => void | Promise<void>;
+
+  return {
+    ...core,
+    useEventListener(callback: EventCallback) {
+      useEffect(() => {
+        return core.subscribe(callback);
+      }, [callback]);
+    },
+  } as const;
+}

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 export type { StandardSchemaV1 } from "@standard-schema/spec";
@@ -39,10 +38,5 @@ export function createBroadcastChannelEventEmitter<T extends StandardSchemaV1>(
       channel.postMessage(validate(data));
     },
     subscribe,
-    useEventListener(callback: EventCallback) {
-      useEffect(() => {
-        return subscribe(callback);
-      }, [callback]);
-    },
   } as const;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 export type { StandardSchemaV1 } from "@standard-schema/spec";
@@ -42,10 +41,5 @@ export function createEventEmitter<T extends StandardSchemaV1>(eventName: string
       element.dispatchEvent(event);
     },
     subscribe,
-    useEventListener(callback: EventCallback) {
-      useEffect(() => {
-        return subscribe(callback);
-      }, [callback]);
-    },
   } as const;
 }

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { createEventEmitter as createCoreEventEmitter } from "./index";
+
+export type { StandardSchemaV1 } from "@standard-schema/spec";
+
+export function createEventEmitter<T extends StandardSchemaV1>(eventName: string, schema: T) {
+  const core = createCoreEventEmitter(eventName, schema);
+
+  type EventOutput = StandardSchemaV1.InferOutput<T>;
+  type EventCallback = (data: EventOutput) => void | Promise<void>;
+
+  return {
+    ...core,
+    useEventListener(callback: EventCallback) {
+      useEffect(() => {
+        return core.subscribe(callback);
+      }, [callback]);
+    },
+  } as const;
+}

--- a/tests/broadcast-react.test.ts
+++ b/tests/broadcast-react.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { createBroadcastChannelEventEmitter } from "../src/broadcast-react";
+
+function createMockSchema<T>(): StandardSchemaV1<T, T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate(value) {
+        return { value: value as T };
+      },
+    },
+  };
+}
+
+function createMockBroadcastChannel() {
+  const listeners: Map<string, Set<(event: MessageEvent) => void>> = new Map();
+
+  return {
+    postMessage: vi.fn((data: unknown) => {
+      const messageListeners = listeners.get("message");
+      if (messageListeners) {
+        const event = new MessageEvent("message", { data });
+        for (const listener of messageListeners) {
+          listener(event);
+        }
+      }
+    }),
+    addEventListener: vi.fn((type: string, listener: (event: MessageEvent) => void) => {
+      if (!listeners.has(type)) {
+        listeners.set(type, new Set());
+      }
+      listeners.get(type)!.add(listener);
+    }),
+    removeEventListener: vi.fn((type: string, listener: (event: MessageEvent) => void) => {
+      listeners.get(type)?.delete(listener);
+    }),
+    close: vi.fn(),
+    name: "test-channel",
+    onmessage: null,
+    onmessageerror: null,
+    dispatchEvent: vi.fn(),
+  } as unknown as BroadcastChannel;
+}
+
+describe("createBroadcastChannelEventEmitter (react)", () => {
+  let channel: BroadcastChannel;
+
+  beforeEach(() => {
+    channel = createMockBroadcastChannel();
+  });
+
+  it("should work with useEventListener hook", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createBroadcastChannelEventEmitter(channel, schema);
+    const callback = vi.fn();
+
+    renderHook(() => emitter.useEventListener(callback));
+    emitter.emit("hook-data");
+
+    expect(callback).toHaveBeenCalledWith("hook-data");
+  });
+
+  it("should clean up useEventListener on unmount", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createBroadcastChannelEventEmitter(channel, schema);
+    const callback = vi.fn();
+
+    const { unmount } = renderHook(() => emitter.useEventListener(callback));
+    emitter.emit("before");
+    unmount();
+    emitter.emit("after");
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("before");
+  });
+
+  it("should expose emit and subscribe from core", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createBroadcastChannelEventEmitter(channel, schema);
+    const callback = vi.fn();
+
+    emitter.subscribe(callback);
+    emitter.emit("passthrough");
+
+    expect(channel.postMessage).toHaveBeenCalledWith("passthrough");
+    expect(callback).toHaveBeenCalledWith("passthrough");
+  });
+});

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { createBroadcastChannelEventEmitter } from "../src/broadcast";
 
@@ -161,30 +160,5 @@ describe("createBroadcastChannelEventEmitter", () => {
     expect(() => {
       emitter.emit("test");
     }).toThrow("Schema validation must be synchronous");
-  });
-
-  it("should work with useEventListener hook", () => {
-    const schema = createMockSchema<string>();
-    const emitter = createBroadcastChannelEventEmitter(channel, schema);
-    const callback = vi.fn();
-
-    renderHook(() => emitter.useEventListener(callback));
-    emitter.emit("hook-data");
-
-    expect(callback).toHaveBeenCalledWith("hook-data");
-  });
-
-  it("should clean up useEventListener on unmount", () => {
-    const schema = createMockSchema<string>();
-    const emitter = createBroadcastChannelEventEmitter(channel, schema);
-    const callback = vi.fn();
-
-    const { unmount } = renderHook(() => emitter.useEventListener(callback));
-    emitter.emit("before");
-    unmount();
-    emitter.emit("after");
-
-    expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith("before");
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { createEventEmitter } from "../src/index";
 
@@ -124,31 +123,6 @@ describe("createEventEmitter", () => {
     expect(() => {
       emitter.emit("test");
     }).toThrow("Schema validation must be synchronous");
-  });
-
-  it("should work with useEventListener hook", () => {
-    const schema = createMockSchema<string>();
-    const emitter = createEventEmitter("test-hook", schema);
-    const callback = vi.fn();
-
-    renderHook(() => emitter.useEventListener(callback));
-    emitter.emit("hook-data");
-
-    expect(callback).toHaveBeenCalledWith("hook-data");
-  });
-
-  it("should clean up useEventListener on unmount", () => {
-    const schema = createMockSchema<string>();
-    const emitter = createEventEmitter("test-cleanup", schema);
-    const callback = vi.fn();
-
-    const { unmount } = renderHook(() => emitter.useEventListener(callback));
-    emitter.emit("before");
-    unmount();
-    emitter.emit("after");
-
-    expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith("before");
   });
 
   it("should emit complex objects", () => {

--- a/tests/react.test.ts
+++ b/tests/react.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { createEventEmitter } from "../src/react";
+
+function createMockSchema<T>(): StandardSchemaV1<T, T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate(value) {
+        return { value: value as T };
+      },
+    },
+  };
+}
+
+describe("createEventEmitter (react)", () => {
+  it("should work with useEventListener hook", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createEventEmitter("test-hook", schema);
+    const callback = vi.fn();
+
+    renderHook(() => emitter.useEventListener(callback));
+    emitter.emit("hook-data");
+
+    expect(callback).toHaveBeenCalledWith("hook-data");
+  });
+
+  it("should clean up useEventListener on unmount", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createEventEmitter("test-cleanup", schema);
+    const callback = vi.fn();
+
+    const { unmount } = renderHook(() => emitter.useEventListener(callback));
+    emitter.emit("before");
+    unmount();
+    emitter.emit("after");
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("before");
+  });
+
+  it("should expose emit and subscribe from core", () => {
+    const schema = createMockSchema<string>();
+    const emitter = createEventEmitter("test-passthrough", schema);
+    const callback = vi.fn();
+
+    emitter.subscribe(callback);
+    emitter.emit("passthrough");
+
+    expect(callback).toHaveBeenCalledWith("passthrough");
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    react: "src/react.ts",
     broadcast: "src/broadcast.ts",
+    "broadcast/react": "src/broadcast-react.ts",
   },
   format: ["esm", "cjs"],
   dts: true,


### PR DESCRIPTION
## Summary

- Restructure package into 4 entry points, decoupling React hooks from the framework-agnostic core (following zustand's pattern)
- `use-custom-event` and `use-custom-event/broadcast` are now React-free; React bindings live at `use-custom-event/react` and `use-custom-event/broadcast/react`
- React is now an optional peer dependency via `peerDependenciesMeta`

### Entry Points

| Import Path | Description | Requires React |
|---|---|---|
| `use-custom-event` | Core event emitter (DOM CustomEvent) | No |
| `use-custom-event/react` | Core + `useEventListener` hook | Yes |
| `use-custom-event/broadcast` | BroadcastChannel event emitter | No |
| `use-custom-event/broadcast/react` | Broadcast + `useEventListener` hook | Yes |

### Breaking Change

`useEventListener` is no longer available from the root or broadcast entry points. Users who rely on the hook need to update their import path:

```diff
- import { createEventEmitter } from "use-custom-event";
+ import { createEventEmitter } from "use-custom-event/react";
```

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 19 tests across 4 files pass
- [x] `pnpm run build` — all 4 entry points built (ESM + CJS + DTS)
- [x] `grep -l "react" dist/index.js dist/broadcast.js` — no React in core bundles
- [x] `pnpm run lint` — 0 warnings, 0 errors